### PR TITLE
fix: replace esm.sh module import with jsdelivr UMD to fix PNG rendering

### DIFF
--- a/references/render_excalidraw.py
+++ b/references/render_excalidraw.py
@@ -120,7 +120,7 @@ def render(
         print(f"ERROR: Template not found at {template_path}", file=sys.stderr)
         sys.exit(1)
 
-    template_url = template_path.as_uri()
+    template_html = template_path.read_text(encoding="utf-8")
 
     with sync_playwright() as p:
         try:
@@ -137,11 +137,11 @@ def render(
             device_scale_factor=scale,
         )
 
-        # Load the template
-        page.goto(template_url)
+        # set_content() avoids file:// CORS blocks on ES module imports
+        page.set_content(template_html)
 
-        # Wait for the ES module to load (imports from esm.sh)
-        page.wait_for_function("window.__moduleReady === true", timeout=30000)
+        # Wait for UMD scripts (React + ExcalidrawLib) to load
+        page.wait_for_function("window.__moduleReady === true", timeout=60000)
 
         # Inject the diagram data and render
         json_str = json.dumps(data)

--- a/references/render_template.html
+++ b/references/render_template.html
@@ -8,50 +8,60 @@
     #root { display: inline-block; }
     #root svg { display: block; }
   </style>
+  <!-- Load React + ReactDOM UMD (must be loaded before Excalidraw) -->
+  <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js"></script>
+  <!-- Load Excalidraw UMD build (exposes window.ExcalidrawLib) -->
+  <script src="https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw/dist/excalidraw.production.min.js"></script>
 </head>
 <body>
   <div id="root"></div>
-
-  <script type="module">
-    import { exportToSvg } from "https://esm.sh/@excalidraw/excalidraw?bundle";
-
-    window.renderDiagram = async function(jsonData) {
-      try {
-        const data = typeof jsonData === "string" ? JSON.parse(jsonData) : jsonData;
-        const elements = data.elements || [];
-        const appState = data.appState || {};
-        const files = data.files || {};
-
-        // Force white background in appState
-        appState.viewBackgroundColor = appState.viewBackgroundColor || "#ffffff";
-        appState.exportWithDarkMode = false;
-
-        const svg = await exportToSvg({
-          elements: elements,
-          appState: {
-            ...appState,
-            exportBackground: true,
-          },
-          files: files,
-        });
-
-        // Clear any previous render
-        const root = document.getElementById("root");
-        root.innerHTML = "";
-        root.appendChild(svg);
-
-        window.__renderComplete = true;
-        window.__renderError = null;
-        return { success: true, width: svg.getAttribute("width"), height: svg.getAttribute("height") };
-      } catch (err) {
-        window.__renderComplete = true;
-        window.__renderError = err.message;
-        return { success: false, error: err.message };
+  <script>
+    (function() {
+      // Wait for ExcalidrawLib to be available (CDN scripts loaded synchronously)
+      if (!window.ExcalidrawLib || !window.ExcalidrawLib.exportToSvg) {
+        window.__moduleReady = false;
+        window.__moduleError = "ExcalidrawLib.exportToSvg not found on window";
+        return;
       }
-    };
 
-    // Signal that the module is loaded and ready
-    window.__moduleReady = true;
+      const exportToSvg = window.ExcalidrawLib.exportToSvg;
+
+      window.renderDiagram = async function(jsonData) {
+        try {
+          const data = typeof jsonData === "string" ? JSON.parse(jsonData) : jsonData;
+          const elements = data.elements || [];
+          const appState = data.appState || {};
+          const files = data.files || {};
+
+          appState.viewBackgroundColor = appState.viewBackgroundColor || "#ffffff";
+          appState.exportWithDarkMode = false;
+
+          const svg = await exportToSvg({
+            elements: elements,
+            appState: {
+              ...appState,
+              exportBackground: true,
+            },
+            files: files,
+          });
+
+          const root = document.getElementById("root");
+          root.innerHTML = "";
+          root.appendChild(svg);
+
+          window.__renderComplete = true;
+          window.__renderError = null;
+          return { success: true, width: svg.getAttribute("width"), height: svg.getAttribute("height") };
+        } catch (err) {
+          window.__renderComplete = true;
+          window.__renderError = err.message;
+          return { success: false, error: err.message };
+        }
+      };
+
+      window.__moduleReady = true;
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

The `render_excalidraw.py` PNG rendering pipeline was broken — all renders failed with a 120-second timeout at `page.wait_for_function("window.__moduleReady === true")`.

## Root Cause

Two issues combined:

1. **`render_template.html`** — used `<script type="module">` to import `@excalidraw/excalidraw?bundle` from `esm.sh`. Chrome blocks cross-origin module imports from `file://` pages.

2. **`esm.sh ?bundle` is not self-contained** — the `?bundle` response for this package still contains 22 nested `import` statements (`import "/@braintree/..."`, etc.), which cannot be resolved in a browser context loading from `file://` or blob URL.

3. **`render_excalidraw.py`** — used `page.goto(file://...)` which triggers the same CORS restrictions.

## Fix

- **Template**: Replace `<script type="module">` esm.sh import with three `<script>` tags loading React, ReactDOM, and Excalidraw UMD builds from jsdelivr. Access `exportToSvg` via `window.ExcalidrawLib.exportToSvg`. Add error handling when ExcalidrawLib is unavailable.
- **Python render script**: Use `page.set_content()` instead of `page.goto(file://...)` to avoid `file://` origin CORS restrictions. Increase module load timeout from 30s to 60s to handle CDN script loading.

## Test Plan

- [x] Simple diagram (rectangle + text) — renders correctly, 25KB PNG
- [x] Complex multi-element diagram (3 boxes + arrows + labels) — renders correctly, 62KB PNG
- [x] All elements (rectangles, text, arrows, labels) appear correctly positioned
- [x] No text overflow, no element overlap