### PR TITLE
docs: bound arrow wiring, container sizing formula, frame element, swimlane pattern

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -190,6 +190,7 @@ For each concept, find the visual pattern that mirrors its behavior:
 | Transforms input to output | **Assembly line** (before → process → after) |
 | Compares two things | **Side-by-side** (parallel with contrast) |
 | Separates into phases | **Gap/Break** (visual separation between sections) |
+| Shows parallel responsibilities / team lanes | **Swimlane** (`frame` elements side-by-side, 60px gap) |
 
 ### Step 3: Ensure Variety
 For multi-concept diagrams: **each major concept must use a different visual pattern**. No uniform cards or grids.
@@ -550,3 +551,4 @@ uv run playwright install chromium
 25. **Arrows land correctly**: Arrows connect to intended elements without crossing others
 26. **Readable at export size**: Text is legible in the rendered PNG
 27. **Balanced composition**: No large empty voids or overcrowded regions
+28. **Arrow bindings wired**: Every arrow that visually connects two shapes has non-null `startBinding`/`endBinding`, AND both shapes list the arrow in their `boundElements`. See `references/element-templates.md` → "Bound Arrow" for the complete 3-element wiring pattern. Null bindings cause arrows to drift when shapes are moved.

--- a/references/element-templates.md
+++ b/references/element-templates.md
@@ -180,3 +180,159 @@ Copy-paste JSON templates for each Excalidraw element type. The `strokeColor` an
 ```
 
 For curves: use 3+ points in `points` array.
+
+## Bound Arrow — Complete 3-Element Wiring
+
+Arrow connections must be **bidirectional**: the arrow holds `startBinding`/`endBinding`, AND each connected shape must list the arrow in its own `boundElements`. Without this wiring, arrows float and drift when shapes are moved in Excalidraw.
+
+```json
+[
+  {
+    "type": "rectangle",
+    "id": "source_rect",
+    "x": 100, "y": 120, "width": 180, "height": 60,
+    "strokeColor": "#1a1a2e", "backgroundColor": "#e8f4f8",
+    "fillStyle": "solid", "strokeWidth": 2, "strokeStyle": "solid",
+    "roughness": 0, "opacity": 100, "angle": 0,
+    "seed": 10001, "version": 1, "versionNonce": 10002,
+    "isDeleted": false, "groupIds": [], "link": null, "locked": false,
+    "roundness": {"type": 3},
+    "boundElements": [
+      {"id": "text_source", "type": "text"},
+      {"id": "conn_arrow",  "type": "arrow"}
+    ]
+  },
+  {
+    "type": "text",
+    "id": "text_source",
+    "x": 145, "y": 143, "width": 90, "height": 20,
+    "text": "Source", "originalText": "Source",
+    "fontSize": 16, "fontFamily": 3,
+    "textAlign": "center", "verticalAlign": "middle",
+    "strokeColor": "#1a1a2e", "backgroundColor": "transparent",
+    "fillStyle": "solid", "strokeWidth": 1, "strokeStyle": "solid",
+    "roughness": 0, "opacity": 100, "angle": 0,
+    "seed": 10003, "version": 1, "versionNonce": 10004,
+    "isDeleted": false, "groupIds": [], "link": null, "locked": false,
+    "containerId": "source_rect", "lineHeight": 1.25, "boundElements": null
+  },
+  {
+    "type": "arrow",
+    "id": "conn_arrow",
+    "x": 282, "y": 150, "width": 118, "height": 0,
+    "strokeColor": "#1a1a2e", "backgroundColor": "transparent",
+    "fillStyle": "solid", "strokeWidth": 2, "strokeStyle": "solid",
+    "roughness": 0, "opacity": 100, "angle": 0,
+    "seed": 10005, "version": 1, "versionNonce": 10006,
+    "isDeleted": false, "groupIds": [], "boundElements": null, "link": null, "locked": false,
+    "points": [[0, 0], [118, 0]],
+    "startBinding": {"elementId": "source_rect", "focus": 0.0, "gap": 2},
+    "endBinding":   {"elementId": "target_rect", "focus": 0.0, "gap": 2},
+    "startArrowhead": null,
+    "endArrowhead": "arrow"
+  },
+  {
+    "type": "rectangle",
+    "id": "target_rect",
+    "x": 400, "y": 120, "width": 180, "height": 60,
+    "strokeColor": "#1a1a2e", "backgroundColor": "#e8f4f8",
+    "fillStyle": "solid", "strokeWidth": 2, "strokeStyle": "solid",
+    "roughness": 0, "opacity": 100, "angle": 0,
+    "seed": 10007, "version": 1, "versionNonce": 10008,
+    "isDeleted": false, "groupIds": [], "link": null, "locked": false,
+    "roundness": {"type": 3},
+    "boundElements": [
+      {"id": "text_target", "type": "text"},
+      {"id": "conn_arrow",  "type": "arrow"}
+    ]
+  },
+  {
+    "type": "text",
+    "id": "text_target",
+    "x": 445, "y": 143, "width": 90, "height": 20,
+    "text": "Target", "originalText": "Target",
+    "fontSize": 16, "fontFamily": 3,
+    "textAlign": "center", "verticalAlign": "middle",
+    "strokeColor": "#1a1a2e", "backgroundColor": "transparent",
+    "fillStyle": "solid", "strokeWidth": 1, "strokeStyle": "solid",
+    "roughness": 0, "opacity": 100, "angle": 0,
+    "seed": 10009, "version": 1, "versionNonce": 10010,
+    "isDeleted": false, "groupIds": [], "link": null, "locked": false,
+    "containerId": "target_rect", "lineHeight": 1.25, "boundElements": null
+  }
+]
+```
+
+**Key rules:**
+- Both the source AND target shape must have `{"id": "<arrow_id>", "type": "arrow"}` in their `boundElements` array.
+- `focus: 0.0` centres the connection on the edge midpoint. `gap: 5` adds a small visual clearance.
+- Never leave bindings as `null` if the arrow visually connects two shapes — null bindings cause drift.
+
+## Frame (Swimlane Container)
+
+Frames create labelled visual sections. Child elements must set `"frameId"` to the frame's id.
+Use for swimlane diagrams comparing parallel processes (e.g., Frontend vs Backend, Before vs After).
+
+```json
+{
+  "type": "frame",
+  "id": "frame1",
+  "x": 0, "y": 0,
+  "width": 400, "height": 500,
+  "name": "Frontend",
+  "isCollapsed": false,
+  "strokeColor": "#e2e2e2",
+  "backgroundColor": "transparent",
+  "fillStyle": "solid",
+  "strokeWidth": 1,
+  "strokeStyle": "solid",
+  "roughness": 0,
+  "opacity": 100,
+  "angle": 0,
+  "seed": 20001,
+  "version": 1,
+  "versionNonce": 20002,
+  "isDeleted": false,
+  "groupIds": [],
+  "boundElements": null,
+  "link": null,
+  "locked": false
+}
+```
+
+**Swimlane layout recipe** (two frames side by side, 60px gap):
+- Frame 1: `x: 0,   width: 400`
+- Frame 2: `x: 460, width: 400`
+- Child elements inside each frame: set `"frameId": "<frame_id>"`
+- Elements that live inside a frame do NOT need to overlap the frame border — place them inside the frame's bounds.
+
+## Container Sizing Guide
+
+Excalidraw does not auto-size containers. Use these formulas to size boxes so text fits without clipping.
+
+**Formula (fontSize 16, lineHeight 1.25, fontFamily 3 / Cascadia):**
+
+```
+char_px  = 9         # approximate glyph width in px at fontSize 16
+line_h   = 20        # fontSize 16 × lineHeight 1.25 = 20px per line
+pad_h    = 40        # horizontal padding total (20px each side)
+pad_v    = 24        # vertical padding total (12px each side)
+
+width  = max_chars_per_line × char_px + pad_h
+height = line_count           × line_h  + pad_v
+```
+
+**Quick reference:**
+
+| Text | Chars | Width | Lines | Height |
+|------|-------|-------|-------|--------|
+| "Start" | 5 | 85px | 1 | 44px → use 60 |
+| "Process step" | 12 | 148px | 1 | 44px → use 60 |
+| "Authentication\nService" | 14 | 166px | 2 | 64px → use 80 |
+| "Load Balancer\n(Round Robin)" | 13 | 157px | 2 | 64px → use 80 |
+
+**Minimum safe sizes:** width ≥ 120px, height ≥ 60px for single-line labels.
+
+**For fontSize 20:** multiply char_px by 1.25 → `char_px = 11`. Add ~8px to padding.
+
+When in doubt, size generously — a slightly larger box looks better than clipped text.


### PR DESCRIPTION
## Summary

Three documentation gaps that cause silent quality problems in generated diagrams.

---

## Bug 1 — Arrow `boundElements` never wired (arrows drift on move)

**Root cause:** The arrow template showed `startBinding`/`endBinding` on the arrow, but did not document the bidirectional requirement: connected shapes must also list the arrow in their own `boundElements` array. Result: LLMs following the template produce arrows with `null` bindings or one-sided bindings. In Excalidraw, these arrows detach from shapes when the shapes are moved.

**Fix (`references/element-templates.md`):** New section **"Bound Arrow — Complete 3-Element Wiring"** with a full copy-paste example: source rectangle → connected arrow → target rectangle, with every cross-reference wired in both directions. Includes explicit rules:
- Both the source AND target shape must have `{"id": "<arrow_id>", "type": "arrow"}` in `boundElements`.
- `focus: 0.0` centres the connection; `gap: 2` adds clearance.
- Never leave bindings null when an arrow visually connects two shapes.

**Fix (`SKILL.md`):** Added Quality Checklist item #28 enforcing the wiring rule.

---

## Bug 2 — No container sizing formula (text overflows boxes)

**Root cause:** The skill gives no guidance on how to calculate container `width`/`height` from text content. LLMs guess — often too small — and text overflows or is clipped inside boxes.

**Fix (`references/element-templates.md`):** New section **"Container Sizing Guide"** with:
- Formula: `width = max_chars_per_line × 9 + 40`, `height = line_count × 20 + 24` (for `fontSize: 16`, `lineHeight: 1.25`)
- Quick-reference table for common labels ("Start", "Process step", "Authentication\nService", etc.)
- Minimum safe sizes: `width ≥ 120`, `height ≥ 60` for single-line labels
- Note for `fontSize: 20`: multiply char_px by 1.25

---

## Bug 3 — No `frame` element template (swimlane diagrams not possible)

**Root cause:** `element-templates.md` had no `frame` element template. LLMs had no way to generate Excalidraw's native labelled frame containers, so swimlane diagrams fell back to background-rectangle workarounds that don't group elements properly.

**Fix (`references/element-templates.md`):** New section **"Frame (Swimlane Container)"** with:
- Complete `type: "frame"` JSON template with all required fields (`name`, `isCollapsed`, etc.)
- Child binding rule: elements inside a frame must set `"frameId": "<frame_id>"`
- Two-frame swimlane layout recipe: frame 1 at `x: 0, width: 400`; frame 2 at `x: 460, width: 400`; 60 px gap

**Fix (`SKILL.md`):** Added swimlane row to the **"Map Concepts to Patterns"** table pointing to `frame` elements.

---

## Test plan

- [ ] Generate a diagram with two connected shapes — verify `startBinding.elementId` matches source, target has arrow in `boundElements`
- [ ] Move a shape in Excalidraw — verify arrow follows (not detached)
- [ ] Generate a diagram with long labels — verify box widths accommodate text without clipping
- [ ] Generate a swimlane diagram (e.g. "Frontend vs Backend") — verify `type: "frame"` elements appear with child `frameId` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)